### PR TITLE
Fixed parse_scandir loop malfunction.

### DIFF
--- a/firehose/parsers/clanganalyzer.py
+++ b/firehose/parsers/clanganalyzer.py
@@ -37,8 +37,7 @@ def parse_scandir(resultdir, analyzerversion=None, sut=None):
     yield Analysis instances
     """
     for filename in glob.glob(os.path.join(resultdir, 'report-*.plist')):
-        for analysis in parse_plist(filename, analyzerversion, sut):
-            yield analysis
+        yield parse_plist(filename, analyzerversion, sut)
 
 def parse_plist(pathOrFile, analyzerversion=None, sut=None, file_=None, stats=None):
     """
@@ -213,6 +212,6 @@ if __name__ == '__main__':
             sys.stdout.write(str(analysis.to_xml()))
             sys.stdout.write('\n')
         else:
-            for result in parse_scandir(path, analyzerversion):
-                sys.stdout.write(str(result.to_xml()))
+            for analysis in parse_scandir(path, analyzerversion):
+                sys.stdout.write(str(analysis.to_xml()))
                 sys.stdout.write('\n')


### PR DESCRIPTION
Hi,
Just noticed this thing when trying to run clanganalyzer.py against a directory produced by scan-build.

parse_scandir is only dispatching work to parse_plist by looping
on the given directory.

The code must be a remainder of a previous Class implementation,
because it was trying to iterate on an Analysis object (result of
parse_plist) that is non-iterable.

Instead, yield the Analysis per plist report until they are processed.
