### PR TITLE
fix references to message elements in the grammar

### DIFF
--- a/firehose.rng
+++ b/firehose.rng
@@ -235,9 +235,7 @@
       </optional>
       <optional>
         <!-- summary of the failure -->
-        <element name="message">
-          <text/>
-        </element>
+        <ref name="message-element"/>
       </optional>
 
       <!--
@@ -275,9 +273,7 @@
         <ref name="location-element"/>
       </optional>
       <optional>
-        <element name="message">
-          <text/>
-        </element>
+        <ref name="message-element"/>
       </optional>
       <optional>
         <ref name="custom-fields-element"/>


### PR DESCRIPTION
Issue uses message-element
Failure and Info used their own-defined message
It's clearer when Issue/Failure/Info use a reference to message-element
