### PR TITLE
travis: remove 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "pypy"
   - "2.7"
-  - "3.2"
   - "3.3"
 script: make
 before_install:


### PR DESCRIPTION
The python 3.2 CI runs have been failing inside "import mock" with:

  RuntimeError: Python 3.3 or later is required

Possibly a misconfiguration on the travis side, but for now,
reduce the noise by disabling this configuration.