### PR TITLE
Replace deprecated distutils with setuptools

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 nose
 mock
 # libxml2-utils
+setuptools
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
 #   USA
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='firehose',
     version='0.5',


### PR DESCRIPTION
As described in [1], distutils is a deprecated module and will be removed in python 3.12. The simplest step forward is substituting it with setuptools.

[1] https://docs.python.org/3/library/distutils.html